### PR TITLE
Removing transparent

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/autobackgroundremover/src/main/java/com/slowmac/autobackgroundremover/BackgroundRemover.kt
+++ b/autobackgroundremover/src/main/java/com/slowmac/autobackgroundremover/BackgroundRemover.kt
@@ -75,6 +75,8 @@ object BackgroundRemover {
     /**
      * Change the background pixels color to transparent.
      * */
+
+
     private suspend fun removeBackgroundFromImage(
         image: Bitmap
     ): Bitmap {
@@ -83,6 +85,7 @@ object BackgroundRemover {
                 for (x in 0 until width) {
                     val bgConfidence = ((1.0 - buffer.float) * 255).toInt()
                     if (bgConfidence >= 100) {
+                        image.setHasAlpha(true)
                         image.setPixel(x, y, 0)
                     }
                 }

--- a/autobackgroundremover/src/main/java/com/slowmac/autobackgroundremover/BackgroundRemover.kt
+++ b/autobackgroundremover/src/main/java/com/slowmac/autobackgroundremover/BackgroundRemover.kt
@@ -75,8 +75,6 @@ object BackgroundRemover {
     /**
      * Change the background pixels color to transparent.
      * */
-
-
     private suspend fun removeBackgroundFromImage(
         image: Bitmap
     ): Bitmap {


### PR DESCRIPTION
previously the code crops the background and puts the transparent color in the image bitmap, so when we try to overlay two image bitmaps the results look like the below Image1 and Image3. Now the function I added removes the transparent colors also from the image bitmap and now you people can easily overlay images like Image2 and Image4.

**Image1**
![WhatsApp Image](https://user-images.githubusercontent.com/90325088/215274616-0dbd9779-2331-4cfd-ac7b-d2e1136c20ad.jpg)

**Image2**
![WhatsApp Image 2023-01-28 at 14 18 51](https://user-images.githubusercontent.com/90325088/215274619-de239253-c309-4438-b8aa-141e3aa4be2a.jpg)

**Image3**
![WhatsApp Image 2023-01-28](https://user-images.githubusercontent.com/90325088/215274683-51be7ee8-e8ae-4eae-961d-42aef3d7929e.jpg)

**Image4**
![WhatsApp Image 2023-01-28 at 14 18 52](https://user-images.githubusercontent.com/90325088/215274628-2aefb34f-ddfe-4103-8fdb-af3531bd8601.jpg)

It is a pleasurable moment for me if this PR got accepted because this is my first contribution. 